### PR TITLE
Unify target frameworks and change root namespaces

### DIFF
--- a/Warframe.NET.sln
+++ b/Warframe.NET.sln
@@ -1,14 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28010.2036
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29326.143
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorldState", "src\WorldState\WorldState.csproj", "{3DAA880B-34B1-4159-9E37-C0CD15819C32}"
-	ProjectSection(ProjectDependencies) = postProject
-		{21D7EFBE-C9C4-4293-8D2D-90BB3B1BBE15} = {21D7EFBE-C9C4-4293-8D2D-90BB3B1BBE15}
-	EndProjectSection
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Warframe", "src\Warframe\Warframe.csproj", "{6A77F81D-1995-41DF-9C98-05A0D8A3B23E}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorldState.Data", "src\WorldState.Data\WorldState.Data.csproj", "{21D7EFBE-C9C4-4293-8D2D-90BB3B1BBE15}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Warframe.World", "src\Warframe.World\Warframe.World.csproj", "{2E18F19D-A822-43FE-B7BA-6B3CCFD19AAE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -16,14 +13,14 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{3DAA880B-34B1-4159-9E37-C0CD15819C32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3DAA880B-34B1-4159-9E37-C0CD15819C32}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3DAA880B-34B1-4159-9E37-C0CD15819C32}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3DAA880B-34B1-4159-9E37-C0CD15819C32}.Release|Any CPU.Build.0 = Release|Any CPU
-		{21D7EFBE-C9C4-4293-8D2D-90BB3B1BBE15}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{21D7EFBE-C9C4-4293-8D2D-90BB3B1BBE15}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{21D7EFBE-C9C4-4293-8D2D-90BB3B1BBE15}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{21D7EFBE-C9C4-4293-8D2D-90BB3B1BBE15}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A77F81D-1995-41DF-9C98-05A0D8A3B23E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A77F81D-1995-41DF-9C98-05A0D8A3B23E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A77F81D-1995-41DF-9C98-05A0D8A3B23E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A77F81D-1995-41DF-9C98-05A0D8A3B23E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E18F19D-A822-43FE-B7BA-6B3CCFD19AAE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E18F19D-A822-43FE-B7BA-6B3CCFD19AAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E18F19D-A822-43FE-B7BA-6B3CCFD19AAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E18F19D-A822-43FE-B7BA-6B3CCFD19AAE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Warframe.World/Enums/FissureTier.cs
+++ b/src/Warframe.World/Enums/FissureTier.cs
@@ -1,4 +1,4 @@
-﻿namespace WorldState.Data.Enums
+﻿namespace Warframe.World.Enums
 {
     public enum FissureTier
     {

--- a/src/Warframe.World/Models/Alert.cs
+++ b/src/Warframe.World/Models/Alert.cs
@@ -1,9 +1,9 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
+using Newtonsoft.Json;
 
-namespace WorldState.Data.Models
+namespace Warframe.World.Models
 {
-    public class SyndicateMission
+    public class Alert
     {
         [JsonProperty]
         public string Id { get; private set; }
@@ -14,17 +14,17 @@ namespace WorldState.Data.Models
         [JsonProperty("expiry")]
         public DateTimeOffset ExpiresAt { get; private set; }
 
+        [JsonProperty]
+        public AlertMission Mission { get; private set; }
+
         [JsonProperty("active")]
         public bool IsActive { get; private set; }
 
-        [JsonProperty]
-        public string Syndicate { get; private set; }
+        [JsonProperty("expired")]
+        public bool HasExpired { get; private set; }
 
         [JsonProperty]
-        public string[] Nodes { get; private set; }
-
-        [JsonProperty("jobs")]
-        public Bounty[] Bounties { get; private set; }
+        public string[] RewardTypes { get; private set; }
 
         [JsonProperty("eta")]
         public string TimeRemaining { get; private set; }

--- a/src/Warframe.World/Models/AlertMission.cs
+++ b/src/Warframe.World/Models/AlertMission.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json;
 
-namespace WorldState.Data.Models
+namespace Warframe.World.Models
 {
     public class AlertMission
     {

--- a/src/Warframe.World/Models/Bounty.cs
+++ b/src/Warframe.World/Models/Bounty.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json;
 
-namespace WorldState.Data.Models
+namespace Warframe.World.Models
 {
     public class Bounty
     {

--- a/src/Warframe.World/Models/ConclaveChallenge.cs
+++ b/src/Warframe.World/Models/ConclaveChallenge.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Newtonsoft.Json;
 
-namespace WorldState.Data.Models
+namespace Warframe.World.Models
 {
     public class ConclaveChallenge
     {

--- a/src/Warframe.World/Models/DailyDeal.cs
+++ b/src/Warframe.World/Models/DailyDeal.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Newtonsoft.Json;
 
-namespace WorldState.Data.Models
+namespace Warframe.World.Models
 {
     public class DailyDeal
     {

--- a/src/Warframe.World/Models/Event.cs
+++ b/src/Warframe.World/Models/Event.cs
@@ -1,7 +1,7 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
+using Newtonsoft.Json;
 
-namespace WorldState.Data.Models
+namespace Warframe.World.Models
 {
     public class Event
     {

--- a/src/Warframe.World/Models/Fissure.cs
+++ b/src/Warframe.World/Models/Fissure.cs
@@ -1,8 +1,8 @@
-﻿using Newtonsoft.Json;
-using System;
-using WorldState.Data.Enums;
+﻿using System;
+using Newtonsoft.Json;
+using Warframe.World.Enums;
 
-namespace WorldState.Data.Models
+namespace Warframe.World.Models
 {
     public class Fissure
     {

--- a/src/Warframe.World/Models/FlashSale.cs
+++ b/src/Warframe.World/Models/FlashSale.cs
@@ -1,7 +1,7 @@
-using Newtonsoft.Json;
 using System;
+using Newtonsoft.Json;
 
-namespace WorldState.Data.Models
+namespace Warframe.World.Models
 {
 	public class FlashSale
 	{

--- a/src/Warframe.World/Models/GlobalUpgrade.cs
+++ b/src/Warframe.World/Models/GlobalUpgrade.cs
@@ -1,7 +1,7 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
+using Newtonsoft.Json;
 
-namespace WorldState.Data.Models
+namespace Warframe.World.Models
 {
     public class GlobalUpgrade
     {

--- a/src/Warframe.World/Models/MissionReward.cs
+++ b/src/Warframe.World/Models/MissionReward.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json;
 
-namespace WorldState.Data.Models
+namespace Warframe.World.Models
 {
     public class MissionReward
     {

--- a/src/Warframe.World/Models/News.cs
+++ b/src/Warframe.World/Models/News.cs
@@ -1,9 +1,9 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 
-namespace WorldState.Data.Models
+namespace Warframe.World.Models
 {
     public class News
     {

--- a/src/Warframe.World/Models/Simaris.cs
+++ b/src/Warframe.World/Models/Simaris.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json;
 
-namespace WorldState.Data.Models
+namespace Warframe.World.Models
 {
     public class Simaris
     {

--- a/src/Warframe.World/Models/Sortie.cs
+++ b/src/Warframe.World/Models/Sortie.cs
@@ -1,7 +1,7 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
+using Newtonsoft.Json;
 
-namespace WorldState.Data.Models
+namespace Warframe.World.Models
 {
     public class Sortie
     {

--- a/src/Warframe.World/Models/SortieVariant.cs
+++ b/src/Warframe.World/Models/SortieVariant.cs
@@ -1,7 +1,7 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
+using Newtonsoft.Json;
 
-namespace WorldState.Data.Models
+namespace Warframe.World.Models
 {
     public class SortieVariant
     {

--- a/src/Warframe.World/Models/SyndicateMission.cs
+++ b/src/Warframe.World/Models/SyndicateMission.cs
@@ -1,9 +1,9 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
+using Newtonsoft.Json;
 
-namespace WorldState.Data.Models
+namespace Warframe.World.Models
 {
-    public class Alert
+    public class SyndicateMission
     {
         [JsonProperty]
         public string Id { get; private set; }
@@ -14,17 +14,17 @@ namespace WorldState.Data.Models
         [JsonProperty("expiry")]
         public DateTimeOffset ExpiresAt { get; private set; }
 
-        [JsonProperty]
-        public AlertMission Mission { get; private set; }
-
         [JsonProperty("active")]
         public bool IsActive { get; private set; }
 
-        [JsonProperty("expired")]
-        public bool HasExpired { get; private set; }
+        [JsonProperty]
+        public string Syndicate { get; private set; }
 
         [JsonProperty]
-        public string[] RewardTypes { get; private set; }
+        public string[] Nodes { get; private set; }
+
+        [JsonProperty("jobs")]
+        public Bounty[] Bounties { get; private set; }
 
         [JsonProperty("eta")]
         public string TimeRemaining { get; private set; }

--- a/src/Warframe.World/Models/SystemResource.cs
+++ b/src/Warframe.World/Models/SystemResource.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json;
 
-namespace WorldState.Data.Models
+namespace Warframe.World.Models
 {
     public class SystemResource
     {

--- a/src/Warframe.World/Warframe.World.csproj
+++ b/src/Warframe.World/Warframe.World.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFramework>netstandard1.6</TargetFramework>
+    <RootNamespace>Warframe.World</RootNamespace>
+    <AssemblyName>Warframe.World</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Warframe/Warframe.csproj
+++ b/src/Warframe/Warframe.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.6</TargetFramework>
+    <RootNamespace>Warframe</RootNamespace>
+    <AssemblyName>Warframe</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/src/WorldState/WorldState.csproj
+++ b/src/WorldState/WorldState.csproj
@@ -1,9 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
-    <RootNamespace>WorldState</RootNamespace>
-    <AssemblyName>WorldState</AssemblyName>
-  </PropertyGroup>
-
-</Project>


### PR DESCRIPTION
This PR has 3 major changes in it:

## 1. Unify target frameworks
Previously, both of the projects targeted different frameworks. WorldState.Data targeted `netstandard1.0` while WorldState targeted `netstandard1.6`. This PR changes WorldState.Data so that it targets `netstandard1.6` as well. This means that the features available through the .net standard would be the same between both projects.

`netstandard1.6` should support most projects. It is supported by .Net Framework 4.6.1+ and .Net Core 1.0+. If you'd like to target an earlier standard, we can change them to both target `netstandard1.0` or `netstandard1.1` instead, but older versions of the standard will also have fewer packages available to them, and I'm not sure what packages this project will use in the future.

## 2. Change root namespaces
"WorldState" as a namespace name does not indicate that this project is related to Warframe. As such, I think it would be better to use "Warframe" in your namespace name. It clarifies that the types under the namespace are related to Warframe in some form or another. While this may seem trivial, in a large project with dozens of packages being imported (such as a multi-purpose discord bot or website), this distinction may be important for the developers so they understand which types are related to Warframe.

We discussed over Discord which namespace you would prefer, and you suggested "Warframe" and "Warframe.Data". I have another suggestion as well, however this PR uses the namespaces that you suggested. My other suggestion is "Wfcd.Warframe"/"Wfcd.Warframe.World". The namespaces I'm suggesting clearly show that the types are not being provided by DE, but are instead WFCD types.

## 3. Update project names
Since the root namespace is changing, I went ahead and changed the project names to match the root namespaces. I can revert this change if you would prefer, but I thought it might make sense to have the project names match the root namespaces.